### PR TITLE
feat(lsproc): add pure-Go /proc process and port discovery on Linux

### DIFF
--- a/internal/lsproc/discover_unix.go
+++ b/internal/lsproc/discover_unix.go
@@ -4,13 +4,61 @@ package lsproc
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 )
 
 func standaloneProcesses() ([]process, error) {
+	if procs, err := standaloneProcessesViaProc(); err == nil && len(procs) > 0 {
+		return procs, nil
+	}
+	return standaloneProcessesViaPS()
+}
+
+func standaloneProcessesViaProc() ([]process, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+
+	var procs []process
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+
+		cmdlineBytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+		if err != nil {
+			continue
+		}
+
+		args := strings.Split(string(cmdlineBytes), "\x00")
+		cmdline := strings.Join(args, " ")
+		cmdline = strings.TrimSpace(cmdline)
+
+		if cmdline == "" || !isStandaloneLS(cmdline) {
+			continue
+		}
+
+		procs = append(procs, process{pid: pid, cmdline: cmdline})
+	}
+
+	if len(procs) == 0 {
+		return nil, errors.New("no standalone processes found in /proc")
+	}
+	return procs, nil
+}
+
+func standaloneProcessesViaPS() ([]process, error) {
 	out, err := exec.Command("ps", "ax", "-o", "pid=,command=").Output()
 	if err != nil {
 		return nil, err
@@ -37,6 +85,9 @@ func standaloneProcesses() ([]process, error) {
 }
 
 func listeningPorts(pid int) ([]int, error) {
+	if ports, err := portsViaProc(pid); err == nil && len(ports) > 0 {
+		return ports, nil
+	}
 	if ports, err := portsViaLsof(pid); err == nil && len(ports) > 0 {
 		return ports, nil
 	}
@@ -44,6 +95,65 @@ func listeningPorts(pid int) ([]int, error) {
 		return ports, nil
 	}
 	return nil, errors.New("could not determine listening ports")
+}
+
+func portsViaProc(pid int) ([]int, error) {
+	fdDir := fmt.Sprintf("/proc/%d/fd", pid)
+	entries, err := os.ReadDir(fdDir)
+	if err != nil {
+		return nil, err
+	}
+
+	socketInodes := make(map[string]bool)
+	for _, entry := range entries {
+		target, err := os.Readlink(filepath.Join(fdDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(target, "socket:[") && strings.HasSuffix(target, "]") {
+			inode := target[8 : len(target)-1]
+			socketInodes[inode] = true
+		}
+	}
+
+	if len(socketInodes) == 0 {
+		return nil, errors.New("no socket inodes found in /proc")
+	}
+
+	var ports []int
+	seen := make(map[int]bool)
+	for _, netFile := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		data, err := os.ReadFile(netFile)
+		if err != nil {
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines[1:] {
+			fields := strings.Fields(line)
+			if len(fields) < 10 {
+				continue
+			}
+			state := fields[3]
+			inode := fields[9]
+			if state == "0A" && socketInodes[inode] { // 0A = TCP_LISTEN
+				addrParts := strings.Split(fields[1], ":")
+				if len(addrParts) == 2 {
+					if port64, err := strconv.ParseInt(addrParts[1], 16, 32); err == nil {
+						port := int(port64)
+						if port > 0 && port <= 65535 && !seen[port] {
+							seen[port] = true
+							ports = append(ports, port)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if len(ports) == 0 {
+		return nil, errors.New("no listening ports matched socket inodes in /proc")
+	}
+	return ports, nil
 }
 
 var lsofPortRe = regexp.MustCompile(`:(\d+)\s+\(LISTEN\)`)

--- a/internal/lsproc/discover_unix_test.go
+++ b/internal/lsproc/discover_unix_test.go
@@ -1,0 +1,68 @@
+//go:build !windows
+
+package lsproc
+
+import (
+	"net"
+	"os"
+	"testing"
+)
+
+func TestPortsViaProcWithLocalListener(t *testing.T) {
+	// If /proc is not available (e.g. macOS), skip
+	if _, err := os.Stat("/proc"); os.IsNotExist(err) {
+		t.Skip("/proc is not available on this platform")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create test listener: %v", err)
+	}
+	defer ln.Close()
+
+	expectedPort := ln.Addr().(*net.TCPAddr).Port
+
+	ports, err := portsViaProc(os.Getpid())
+	if err != nil {
+		t.Fatalf("portsViaProc failed: %v", err)
+	}
+
+	found := false
+	for _, p := range ports {
+		if p == expectedPort {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("portsViaProc did not find expected port %d in %v", expectedPort, ports)
+	}
+}
+
+func TestListeningPortsFallbackChain(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create test listener: %v", err)
+	}
+	defer ln.Close()
+
+	expectedPort := ln.Addr().(*net.TCPAddr).Port
+
+	ports, err := listeningPorts(os.Getpid())
+	if err != nil {
+		t.Fatalf("listeningPorts failed: %v", err)
+	}
+
+	found := false
+	for _, p := range ports {
+		if p == expectedPort {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("listeningPorts did not find expected port %d in %v", expectedPort, ports)
+	}
+}


### PR DESCRIPTION
### Summary
On minimal Linux distros and containerized environments (Docker, Podman, LXC, WSL2, Debian/Ubuntu slim, Alpine), neither `lsof` nor `iproute2` (`ss`) is installed by default. This causes `listeningPorts(pid)` to fail silently with `could not determine listening ports`, leaving `agy-remote` hanging indefinitely while waiting for the language server.

### Changes
1. **Pure-Go `/proc` port discovery (`portsViaProc`)**:
   - Inspects socket inodes from `/proc/<pid>/fd/*`.
   - Matches active listening sockets (`0A` / `TCP_LISTEN`) against `/proc/net/tcp` and `/proc/net/tcp6`.
   - Resolves ports directly in-process with zero external binary dependencies (`lsof`/`ss`).
2. **Pure-Go process scanning (`standaloneProcessesViaProc`)**:
   - Reads `/proc/<pid>/cmdline` if `ps` is not available in minimal images.
3. **Preserved Fallbacks**:
   - On macOS / non-proc platforms, cleanly falls back to `lsof` and `ss`.
4. **Automated Tests**:
   - Added `discover_unix_test.go` verifying socket resolution against live listeners.