### PR TITLE
fix: start folder picker at configured workspace root

### DIFF
--- a/internal/patches/patches_test.go
+++ b/internal/patches/patches_test.go
@@ -92,7 +92,7 @@ func TestPatchedContentIsCorrect(t *testing.T) {
 		`window.matchMedia("(pointer:coarse)")`,
 		`var vz=function(){return null};var vzDisabled=(`,
 		`function wmb(){return null};function wmbDisabled(`,
-		`initialPath:b?b.fsPath:"/home/ubuntu/workspace",fetchDirectoryContents:`,
+		`initialPath:"/home/ubuntu/workspace",fetchDirectoryContents:`,
 		`var e=(window.matchMedia&&window.matchMedia("(pointer:coarse)").matches)||!!this.storageService`,
 		`isMobileNew=Boolean(window.matchMedia&&window.matchMedia("(pointer:coarse)").matches&&sec)`,
 		`!a.location.search?.section`,

--- a/internal/patches/registry.go
+++ b/internal/patches/registry.go
@@ -150,8 +150,8 @@ func All() []Patch {
 			Replace: `x.createElement(gZ,{iconName:"arrow_back",onClick:()=>c({clearSection:!0}),"aria-label":"Back to home",dataTestId:"mobile-back-to-home"})`,
 		},
 
-		// Only the fallback is replaced: when a workspace is already open the
-		// picker keeps starting from it.
+		// Always start the folder picker at the configured workspace root instead of
+		// falling back to homeDirUri (b).
 		{
 			ID:     "folder-picker-initial-path",
 			Desc:   "Start the folder picker at the configured workspace root",
@@ -162,7 +162,7 @@ func All() []Patch {
 			},
 			Find: `initialPath:b?b.fsPath:Sf?"C:/":"/",fetchDirectoryContents:`,
 			ReplaceFn: func(o Options) string {
-				return `initialPath:b?b.fsPath:` + jsString(o.WorkspaceRoot) + `,fetchDirectoryContents:`
+				return `initialPath:` + jsString(o.WorkspaceRoot) + `,fetchDirectoryContents:`
 			},
 		},
 


### PR DESCRIPTION
## Overview
- Fixes an issue where the interactive folder picker always opened at the user's home directory (`homeDirUri`) instead of the configured `WorkspaceRoot` when creating a new project.

## Changes
- `internal/patches/registry.go`: Updated `folder-picker-initial-path` patch to directly set `initialPath` to `WorkspaceRoot` rather than using the ternary fallback.
- `internal/patches/patches_test.go`: Updated patch test expectations.