### PR TITLE
fix: optimize mobile safe area insets and restore project new conversation button

### DIFF
--- a/internal/patches/patches_test.go
+++ b/internal/patches/patches_test.go
@@ -47,6 +47,8 @@ var regexpFixtures = map[string]string{
 	"mobile-new-convo-view":                     `const tub=()=>{var a=yM(),b=IT();return(0,x.useCallback)((c,e)=>{b(HT.map(f=>({trigger:f,ran:!1})));a(c,{section:e})},[a,b])};` + "\n" + `var uub=()=>{var a=tub(),{q:b}=dM({strict:!1});return x.createElement("div",{className:"w-full h-full flex flex-col min-h-0 animate-fade-in"},x.createElement("div",{className:"flex-1 min-h-0 overflow-y-auto flex flex-col gap-6 pt-3"},x.createElement(sub,{surface:"background"})),x.createElement("div",{className:"shrink-0 p-2"},x.createElement(e_,{cascadeId:void 0},x.createElement(b_,{conversationId:void 0,isLoading:!1,dropdownPlacement:"top-start",openConversationOptimistically:a,showBottomToolbar:!0,` + "\n" + `aboveContent:x.createElement(s_,null),initialQuery:b}))))};`,
 	"mobile-new-convo-header":                   `CM=()=>QL({select:a=>a.location.pathname==="/"})`,
 	"mobile-back-clears-section":                `x.createElement(gZ,{iconName:"arrow_back",onClick:()=>c(),"aria-label":"Back to home",dataTestId:"mobile-back-to-home"})`,
+	"mobile-project-add-button":                 `if(d==="project"||d==="environment"||d==="status"){let za=B?void 0:d==="project"?"New Conversation in Project":d==="environment"?"New Conversation in Workspace":void 0`,
+	"mobile-project-header-actions":             `className:Pm("absolute right-1 top-0 flex h-full items-center gap-1",k||t?"opacity-100":"opacity-0 group-hover/header:opacity-100 group-focus-within/header:opacity-100")`,
 	"folder-picker-initial-path":                `initialPath:b?b.fsPath:Sf?"C:/":"/",fetchDirectoryContents:`,
 	"composer-upload-menu-item":                 `{icon:ea=>x.createElement(T,{name:"image",size:ea.width?Number(ea.width):14,className:ea.className}),` + "\n" + `label:"Media",onClick:oa}`,
 	"file-upload-accept-all":                    `accept:".png,.jpg,.jpeg,.gif,image/png,image/jpeg,image/gif,video/webm,.mp4,video/mp4,.pdf,application/pdf,.txt,text/plain,.csv,text/csv,.json,application/json,.md,text/markdown,.py,text/x-python,.js,.mjs,text/javascript,.ts,.tsx,text/x-typescript,.html,.htm,text/html,.css,text/css",multiple:!0`,
@@ -116,6 +118,8 @@ func TestPatchedContentIsCorrect(t *testing.T) {
 		`isMobileNew=Boolean(window.matchMedia&&window.matchMedia("(pointer:coarse)").matches&&sec)`,
 		`!a.location.search?.section`,
 		`onClick:()=>c({clearSection:!0})`,
+		`if(true){let za=`,
+		`className:Pm("absolute right-1 top-0 flex h-full items-center gap-1","opacity-100")`,
 	}
 	for _, w := range want {
 		if !strings.Contains(body, w) {

--- a/internal/patches/registry.go
+++ b/internal/patches/registry.go
@@ -13,7 +13,9 @@ var (
 
 	skipOnboardingRe = regexp.MustCompile(`c\.hasOnboardingScreens&&[a-zA-Z0-9_$]+!==2&&[a-zA-Z0-9_$]+\(\{to:"/onboarding",replace:!0,throw:!0\}\)`)
 
-	mobileEnterNewlineRe = regexp.MustCompile(`registerCommand\(([a-zA-Z0-9_$]+),k=>\{if\(!k\)return!1;k\.preventDefault\(\);`)
+	mobileEnterNewlineRe         = regexp.MustCompile(`registerCommand\(([a-zA-Z0-9_$]+),k=>\{if\(!k\)return!1;k\.preventDefault\(\);`)
+	mobileProjectAddButtonRe     = regexp.MustCompile(`if\(d==="project"\|\|d==="environment"\|\|d==="status"\)\{let\s+([a-zA-Z0-9_$]+)=([a-zA-Z0-9_$]+)\?void 0:([a-zA-Z0-9_$]+)==="project"\?"New Conversation in Project":([a-zA-Z0-9_$]+)==="environment"\?"New Conversation in Workspace":[\r\n\s]*void 0`)
+	mobileProjectHeaderActionsRe = regexp.MustCompile(`className:Pm\("absolute right-1 top-0 flex h-full items-center gap-1",([a-zA-Z0-9_$]+)\|\|([a-zA-Z0-9_$]+)\?"opacity-100":"opacity-0 group-hover/header:opacity-100 group-focus-within/header:opacity-100"\)`)
 
 	hideMicButtonRe = regexp.MustCompile(`([a-zA-Z0-9_$]+\.displayName="GutterHoverCommentButton";var )([a-zA-Z0-9_$]+)=\(`)
 
@@ -153,7 +155,7 @@ func All() []Patch {
 			Kind:    Regexp,
 			Enabled: mobile,
 			FindRe:  mobileNewConvoViewRe,
-			Replace: `var $2=()=>{var a=$3(),b=$4();return(0,$5.useCallback)((c,$6)=>{b($7.map(f=>({trigger:f,ran:!1})));a(c,{section:$6,replace:!0})},[a,b])};var $8=()=>{var a=$2(),{q:b,section:sec}=$9({strict:!1}),isMobileNew=Boolean(window.matchMedia&&window.matchMedia("(pointer:coarse)").matches&&sec);return $10.createElement("div",{className:"w-full h-full flex flex-col min-h-0 animate-fade-in"},isMobileNew?$10.createElement("div",{className:"flex-1 min-h-0 flex flex-col items-center justify-center gap-3 select-none"},$10.createElement(typeof T!=="undefined"?T:typeof U!=="undefined"?U:"span",{name:"auto_awesome",size:32,className:"text-muted-foreground/30"}),$10.createElement("span",{className:"text-xs text-muted-foreground/60"},"Start a new conversation")):$10.createElement("div",{className:"flex-1 min-h-0 overflow-y-auto flex flex-col gap-6 pt-3"},$10.createElement($13,{surface:"background"})),$10.createElement("div",{className:"shrink-0 p-2"},$10.createElement($16,{cascadeId:void 0},$10.createElement($18,{conversationId:void 0,isLoading:!1,dropdownPlacement:"top-start",openConversationOptimistically:a,showBottomToolbar:!0,aboveContent:$10.createElement($20,null),initialQuery:b}))))};`,
+			Replace: `var $2=()=>{var a=$3(),b=$4();return(0,$5.useCallback)((c,$6)=>{b($7.map(f=>({trigger:f,ran:!1})));a(c,{section:$6,replace:!0})},[a,b])};var $8=()=>{var a=$2(),{q:b,section:sec}=$9({strict:!1}),isMobileNew=Boolean(window.matchMedia&&window.matchMedia("(pointer:coarse)").matches&&sec);return $10.createElement("div",{className:"w-full h-full flex flex-col min-h-0 animate-fade-in"},isMobileNew?$10.createElement("div",{className:"flex-1 min-h-0 flex flex-col items-center justify-center gap-3 select-none"},$10.createElement(typeof U==="function"?U:typeof T==="function"?T:"span",{name:"auto_awesome",size:32,className:"text-muted-foreground/30"}),$10.createElement("span",{className:"text-xs text-muted-foreground/60"},"Start a new conversation")):$10.createElement("div",{className:"flex-1 min-h-0 overflow-y-auto flex flex-col gap-6 pt-3"},$10.createElement($13,{surface:"background"})),$10.createElement("div",{className:"shrink-0 p-2"},$10.createElement($16,{cascadeId:void 0},$10.createElement($18,{conversationId:void 0,isLoading:!1,dropdownPlacement:"top-start",openConversationOptimistically:a,showBottomToolbar:!0,aboveContent:$10.createElement($20,null),initialQuery:b}))))};`,
 		},
 
 		// On mobile, show the back button in the main titlebar when a project is selected
@@ -175,6 +177,24 @@ func All() []Patch {
 			Enabled: mobile,
 			FindRe:  mobileBackClearsSectionRe,
 			Replace: `${1}${2}({clearSection:!0})${3}`,
+		},
+		{
+			ID:      "mobile-project-add-button",
+			Desc:    "Enable the New Conversation + button next to project rows on mobile",
+			Target:  MainJS,
+			Kind:    Regexp,
+			Enabled: mobile,
+			FindRe:  mobileProjectAddButtonRe,
+			Replace: `if(true){let $1=$3==="environment"?"New Conversation in Workspace":"New Conversation in Project"`,
+		},
+		{
+			ID:      "mobile-project-header-actions",
+			Desc:    "Always show project header actions (add conversation button and menu) on touch devices",
+			Target:  MainJS,
+			Kind:    Regexp,
+			Enabled: mobile,
+			FindRe:  mobileProjectHeaderActionsRe,
+			Replace: `className:Pm("absolute right-1 top-0 flex h-full items-center gap-1","opacity-100")`,
 		},
 
 		// Always start the folder picker at the configured workspace root instead of
@@ -349,18 +369,28 @@ body {
     top: 0 !important;
     left: 0 !important;
     right: 0 !important;
-    bottom: var(--agy-bottom, env(safe-area-inset-bottom, 0px)) !important;
+    bottom: var(--agy-bottom, 0px) !important;
     height: auto !important;
     max-height: none !important;
     padding-top: 0 !important;
     padding-bottom: 0 !important;
     box-sizing: border-box !important;
   }
+  div.shrink-0.p-2 {
+    padding: 0.25rem 0.5rem 0 0.5rem !important;
+  }
+  /* When keyboard is active, collapse the safe-area inset on the input box so it hugs the keyboard tightly */
+  body.agy-kb-open [data-testid="agent-input-box"],
+  html[style*="--agy-bottom"] [data-testid="agent-input-box"],
+  body.agy-kb-open .shrink-0.p-2,
+  html[style*="--agy-bottom"] .shrink-0.p-2 {
+    padding-bottom: 0px !important;
+  }
   .aux-drawer-popup {
     padding-bottom: var(--agy-bottom, env(safe-area-inset-bottom, 0px)) !important;
   }
   .fixed.bottom-3 {
-    bottom: calc(0.75rem + var(--agy-bottom, env(safe-area-inset-bottom, 0px))) !important;
+    bottom: calc(0.75rem + var(--agy-bottom, 0px)) !important;
   }
 }
 </style>`
@@ -427,6 +457,7 @@ const keyboardDetect = `<script id="agy-keyboard-detect">
   var predicted = 0;
   try {
     predicted = parseInt(localStorage.getItem("agy-kb"), 10) || 0;
+    if (predicted < 100) predicted = 0;
   } catch (e) {}
   var holdUntil = 0;
 
@@ -443,10 +474,12 @@ const keyboardDetect = `<script id="agy-keyboard-detect">
 
     var opening = applied === 0 && kb > 0;
     applied = kb;
-    if (kb) {
+    if (kb > 0) {
       document.documentElement.style.setProperty("--agy-bottom", kb + "px");
+      document.body.classList.add("agy-kb-open");
     } else {
       document.documentElement.style.removeProperty("--agy-bottom");
+      document.body.classList.remove("agy-kb-open");
     }
     if (opening) scrollChatToBottom();
   }
@@ -455,7 +488,7 @@ const keyboardDetect = `<script id="agy-keyboard-detect">
     unpan();
 
     var target = Math.max(0, Math.round(base() - vv.height));
-    if (target <= 20) target = 0;
+    if (target < 100) target = 0;
 
     if (target > 0) {
       holdUntil = 0;
@@ -526,6 +559,10 @@ const keyboardDetect = `<script id="agy-keyboard-detect">
       }
       track(900);
     }
+  });
+
+  window.addEventListener("focusout", function () {
+    track(500);
   });
 })();
 </script>`


### PR DESCRIPTION
## Summary
- **Restore Project (+) New Conversation Button**: Re-enable project action buttons on touch devices (`mobile-project-add-button`, `mobile-project-header-actions`) hidden by 2.9.1 mobile layout logic.
- **Optimize Mobile Safe Area & Virtual Keyboard Gap**:
  - Closed keyboard: Snap outer container to bottom (`0px`) and apply compact wrapper padding without double safe area gap.
  - Active keyboard: Toggle `.agy-kb-open` class to collapse `agent-input-box` safe-area bottom padding to `0px`, placing the composer snugly above the software keyboard.
  - Keyboard dismissal: Listen to `focusout` for smooth geometry restoration.
- **Unit & E2E Tests**: Add fixtures in `patches_test.go` and verify via Playwright mobile tests.

## Verification
- `go test -v ./...` (100% PASS)
- `go vet ./...` (PASS)
- Playwright E2E: Verified on iPhone 14/17 Pro viewports with 0 console errors.