### PR TITLE
fix: resolve auto-updater permission issues, missing ide_version, and set -e hazards

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,9 @@ func GeminiDir() string {
 // Dir is the data directory holding credentials and sessions.
 func (c *Config) Dir() string { return c.dir }
 
+// SetDir overrides the data directory path (useful for testing).
+func (c *Config) SetDir(dir string) { c.dir = dir }
+
 // Path resolves name inside the data directory.
 func (c *Config) Path(name string) string { return filepath.Join(c.dir, name) }
 

--- a/internal/updater/install.go
+++ b/internal/updater/install.go
@@ -18,6 +18,29 @@ import (
 // ProgressFn reports download progress.
 type ProgressFn func(downloaded, total int64)
 
+// CheckWritable verifies that targetPath and its parent directory can be written to before downloading artifacts.
+func CheckWritable(targetPath string) error {
+	if targetPath == "" {
+		return errors.New("target path cannot be empty")
+	}
+
+	targetDir := filepath.Dir(targetPath)
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("create target directory %s: %w", targetDir, err)
+	}
+
+	// Test write permissions by creating and removing a temporary check file
+	tmpFile, err := os.CreateTemp(targetDir, ".permcheck.*.tmp")
+	if err != nil {
+		return fmt.Errorf("cannot write to directory %s (permission denied): %w", targetDir, err)
+	}
+	tmpName := tmpFile.Name()
+	_ = tmpFile.Close()
+	_ = os.Remove(tmpName)
+
+	return nil
+}
+
 // DownloadAndInstall downloads the official Antigravity artifact and installs language_server to targetPath.
 func DownloadAndInstall(ctx context.Context, url, targetPath string, progress ProgressFn) error {
 	if ctx == nil {
@@ -25,6 +48,11 @@ func DownloadAndInstall(ctx context.Context, url, targetPath string, progress Pr
 	}
 	if targetPath == "" {
 		return errors.New("targetPath cannot be empty")
+	}
+
+	// Pre-flight check: ensure target directory is writable before initiating ~170MB download
+	if err := CheckWritable(targetPath); err != nil {
+		return err
 	}
 
 	// Defense-in-depth: validate download URL domain
@@ -37,9 +65,6 @@ func DownloadAndInstall(ctx context.Context, url, targetPath string, progress Pr
 	}
 
 	targetDir := filepath.Dir(targetPath)
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		return fmt.Errorf("create target directory %s: %w", targetDir, err)
-	}
 
 	client := &http.Client{Timeout: 30 * time.Minute}
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)

--- a/internal/updater/service.go
+++ b/internal/updater/service.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"context"
 	"log"
+	"os"
 	"time"
 
 	"github.com/AFSlayer/antigravity-server/internal/config"
@@ -58,8 +59,30 @@ func checkAndApply(ctx context.Context, cfg *config.Config, targetPath string, r
 		return
 	}
 
+	// Self-healing: if ide_version was missing or unknown in config, but the binary
+	// already exists on disk, record the version without re-downloading ~170MB artifact.
+	if currentVersion == "unknown" {
+		if st, statErr := os.Stat(targetPath); statErr == nil && st.Size() > 10*1024*1024 {
+			cfg.IDEVersion = info.LatestVersion
+			if cfg.LanguageServer == "" {
+				cfg.LanguageServer = targetPath
+			}
+			if saveErr := cfg.Save(); saveErr != nil {
+				log.Printf("[auto-updater] warning: could not save config.json: %v", saveErr)
+			}
+			log.Printf("[auto-updater] recorded missing ide_version as %s from existing binary at %s", info.LatestVersion, targetPath)
+			return
+		}
+	}
+
 	if !info.UpdateAvailable {
 		log.Printf("[auto-updater] Antigravity is up to date (%s)", currentVersion)
+		return
+	}
+
+	// Pre-flight permission check: abort before downloading 170MB if the target directory is not writable
+	if err := CheckWritable(targetPath); err != nil {
+		log.Printf("[auto-updater] cannot update to %s: %v. Please run 'sudo agy-server update' to update.", info.LatestVersion, err)
 		return
 	}
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/AFSlayer/antigravity-server/internal/config"
 )
 
 func TestValidateDownloadURL(t *testing.T) {
@@ -184,5 +186,60 @@ func TestAutoUpdaterReloadLS(t *testing.T) {
 
 	if !reloadCalled {
 		t.Errorf("expected reloadLS to be called upon successful update")
+	}
+}
+
+func TestCheckWritable(t *testing.T) {
+	tmpDir := t.TempDir()
+	validTarget := filepath.Join(tmpDir, "bin", "language_server")
+	if err := CheckWritable(validTarget); err != nil {
+		t.Errorf("CheckWritable(%q) unexpected error: %v", validTarget, err)
+	}
+
+	// Non-writable directory check
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	if err := os.MkdirAll(readOnlyDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(readOnlyDir, 0755) }()
+
+	readOnlyTarget := filepath.Join(readOnlyDir, "language_server")
+	// If run as non-root, this should error
+	if os.Geteuid() != 0 {
+		if err := CheckWritable(readOnlyTarget); err == nil {
+			t.Errorf("CheckWritable(%q) expected error for read-only directory, got nil", readOnlyTarget)
+		}
+	}
+}
+
+func TestCheckAndApplySelfHealsMissingVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	targetPath := filepath.Join(tmpDir, "language_server")
+
+	// Create a mock binary file larger than 10MB
+	data := make([]byte, 11*1024*1024)
+	if err := os.WriteFile(targetPath, data, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		IDEVersion:     "", // missing
+		LanguageServer: targetPath,
+	}
+	cfg.SetDir(tmpDir)
+
+	var reloadCalled bool
+	reloadLS := func() {
+		reloadCalled = true
+	}
+
+	// When checkAndApply runs on existing binary with unknown version, it should self-heal and record version without calling reloadLS
+	checkAndApply(context.Background(), cfg, targetPath, reloadLS)
+
+	if reloadCalled {
+		t.Errorf("expected reloadLS NOT to be called on self-healing path")
+	}
+	if cfg.IDEVersion == "" || cfg.IDEVersion == "unknown" {
+		t.Errorf("expected ide_version to be self-healed, got %q", cfg.IDEVersion)
 	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -173,12 +173,28 @@ install_agy_server() {
 install_language_server() {
   if [ -x "$LS_DIR/language_server" ]; then
     ok "language_server already present at $LS_DIR/language_server"
+    if [ -z "${IDE_VERSION:-}" ]; then
+      local hub_url
+      hub_url="$(resolve_hub_url 2>/dev/null || true)"
+      if [ -n "$hub_url" ]; then
+        IDE_VERSION="$(hub_version "$hub_url")"
+      fi
+    fi
+    sudo_run chown -R "$(id -un):$(id -gn)" "$LS_DIR" 2>/dev/null || true
     return
   fi
 
   if [ "$LS_DIR_EXPLICIT" = "no" ] && [ -x "$LEGACY_LS_DIR/language_server" ]; then
     LS_DIR="$LEGACY_LS_DIR"
     ok "Reusing language_server from $LS_DIR"
+    if [ -z "${IDE_VERSION:-}" ]; then
+      local hub_url
+      hub_url="$(resolve_hub_url 2>/dev/null || true)"
+      if [ -n "$hub_url" ]; then
+        IDE_VERSION="$(hub_version "$hub_url")"
+      fi
+    fi
+    sudo_run chown -R "$(id -un):$(id -gn)" "$LS_DIR" 2>/dev/null || true
     return
   fi
 
@@ -203,6 +219,7 @@ install_language_server() {
 
   sudo_run install -d "$LS_DIR"
   sudo_run install -m 0755 "$tmp/language_server" "$LS_DIR/language_server"
+  sudo_run chown -R "$(id -un):$(id -gn)" "$LS_DIR"
   ok "Installed $LS_DIR/language_server"
 
   IDE_VERSION="$version"
@@ -211,7 +228,9 @@ install_language_server() {
 write_config() {
   local args=(config --port "$PORT" --language-server "$LS_DIR/language_server")
 
-  [ -n "$WORKSPACE_ROOT" ] && args+=(--workspace-root "$WORKSPACE_ROOT")
+  if [ -n "$WORKSPACE_ROOT" ]; then
+    args+=(--workspace-root "$WORKSPACE_ROOT")
+  fi
   if [ -n "$DOMAIN" ]; then
     args+=(--public-url "https://$DOMAIN" --trusted-proxies "127.0.0.1/32,::1/128")
   fi
@@ -328,8 +347,12 @@ main() {
   trap 'rm -rf "$WORK_DIR"' EXIT
 
   heading "Setup"
-  [ -n "$DOMAIN" ] || DOMAIN="$(ask 'Domain for HTTPS (blank to skip)' '')"
-  [ -n "$WORKSPACE_ROOT" ] || WORKSPACE_ROOT="$(ask 'Workspace folder' "$HOME/workspace")"
+  if [ -z "$DOMAIN" ]; then
+    DOMAIN="$(ask 'Domain for HTTPS (blank to skip)' '')"
+  fi
+  if [ -z "$WORKSPACE_ROOT" ]; then
+    WORKSPACE_ROOT="$(ask 'Workspace folder' "$HOME/workspace")"
+  fi
 
   heading "Downloading"
   install_agy_server


### PR DESCRIPTION
## Summary
Closes #19

### Key Fixes:
1. **Self-heal and record missing `ide_version`**:
   - `scripts/install.sh` now resolves and retains the remote build version when reusing existing `language_server` binaries.
   - `internal/updater/service.go` adds a self-healing path: if `ide_version` is missing/unknown but a valid binary already exists on disk, it records the latest version in `config.json` without redundantly re-downloading the ~170MB artifact.
2. **Pre-flight write permission checks & directory ownership**:
   - Added `CheckWritable(targetPath)` to abort before initiating large downloads if the user does not have write permissions to the destination directory.
   - `scripts/install.sh` ensures `LS_DIR` is owned by the service user (`chown -R $(id -un):$(id -gn) $LS_DIR`).
3. **Prevent `set -e` hazards**:
   - Replaced short-circuit list assignments in `scripts/install.sh` with explicit `if` blocks.
4. **Unit tests**:
   - Added `TestCheckWritable` and `TestCheckAndApplySelfHealsMissingVersion`.