### PR TITLE
fix: preserve horizontal row layout for queued messages with delete action

### DIFF
--- a/internal/patches/patches_test.go
+++ b/internal/patches/patches_test.go
@@ -225,6 +225,8 @@ func TestHTMLInjection(t *testing.T) {
 		`/__agy/api/signin/status`,
 		`href="/apple-touch-icon.png"`,
 		`src="/main.js?agy=testkey"`,
+		`div[data-testid="user-input-step"] div.bg-card:has(.user-input-buttons-container)`,
+		`div[data-testid="user-input-step"] div.bg-card:has([data-testid="queued-decorators"])`,
 	}
 	for _, w := range want {
 		if !strings.Contains(body, w) {

--- a/internal/patches/registry.go
+++ b/internal/patches/registry.go
@@ -540,13 +540,20 @@ body {
     padding-bottom: 0px !important;
   }
   /* Flow user message action buttons (Undo, Copy, Timestamp) naturally without overlapping message text */
-  div[data-testid="user-input-step"] div.bg-card:not(.user-input-buttons-container),
-  .group\/user-input-step div.bg-card:not(.user-input-buttons-container) {
+  div[data-testid="user-input-step"] div.bg-card:has(.user-input-buttons-container):not(.user-input-buttons-container),
+  .group\/user-input-step div.bg-card:has(.user-input-buttons-container):not(.user-input-buttons-container) {
     display: flex !important;
     flex-direction: column !important;
     align-items: stretch !important;
     overflow: visible !important;
     position: relative !important;
+  }
+  /* Keep queued messages (waiting in execution queue) on a single row with the delete icon */
+  div[data-testid="user-input-step"] div.bg-card:has([data-testid="queued-decorators"]),
+  .group\/user-input-step div.bg-card:has([data-testid="queued-decorators"]) {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: flex-end !important;
   }
   div[data-testid="user-input-step"] div.user-input-buttons-container,
   .group\/user-input-step div.user-input-buttons-container,


### PR DESCRIPTION
## Summary
- Fixes queued message bubble (waiting in execution queue) breaking delete/trash icon into an unwanted new line
- Constrains `flex-direction: column !important` exclusively to cards that contain `.user-input-buttons-container` using `:has(.user-input-buttons-container)`
- Explicitly ensures queued message bubbles with `[data-testid="queued-decorators"]`: preserve single-line `flex-direction: row !important; align-items: flex-end !important;`
- Adaptive & resilient: relies on semantic testid and class tokens (`user-input-buttons-container`, `queued-decorators`) rather than fragile Tailwind utility lists
- Adds regression test coverage in `patches_test.go`